### PR TITLE
add hifi

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Configurations and todos to make your Arch Linux the best Arch Linux
 - [Multimedia](#multimedia)
   - [Fix bluetooth audio](#fix-bluetooth-audio)
   - [MPV hardware decoding (NVIDIA VDPAU)](#mpv-hardware-decoding-nvidia-vdpau)
+  - [Enable hifi](#enable-hifi)
 
 # System
 
@@ -366,3 +367,36 @@ interpolation
 tscale=oversample
 ```
 
+## Enable hifi
+
+[Arch Wiki reference](https://wiki.archlinux.org/index.php/PulseAudio#daemon.conf)
+
+Edit /etc/pulse/daemon.conf (use higher values if supported; src-sinc-medium-quality can be changed to src-sinc-best-quality)
+
+```
+default-sample-format = s24le
+default-sample-rate = 96000
+avoid-resampling = true
+resample-method = src-sinc-medium-quality
+```
+
+Restart pulseaudio:
+
+```bash
+pulseaudio -k
+pulseaudio --start
+```
+
+Sometimes disabling powersaving may help too. If you use intel's driver (to check run lspci -k), create or edit /etc/modprobe.d/sound.conf
+
+```
+options snd-hda-intel power_save=0
+```
+
+Then run and reboot:
+
+```bash
+sudo mkinitcpio -P
+```
+
+*NB: Enabled high sample rate may cause distortions and higher cpu usage. Pulseaudio 11 or newer required.

--- a/README.md
+++ b/README.md
@@ -371,13 +371,13 @@ tscale=oversample
 
 [Arch Wiki reference](https://wiki.archlinux.org/index.php/PulseAudio#daemon.conf)
 
-Edit /etc/pulse/daemon.conf (use higher values if supported; src-sinc-medium-quality can be changed to src-sinc-best-quality)
+Edit /etc/pulse/daemon.conf (for different resample methods run pulseaudio --dump-resample-methods)
 
 ```
-default-sample-format = s24le
+default-sample-format = s32le
 default-sample-rate = 96000
 avoid-resampling = true
-resample-method = src-sinc-medium-quality
+resample-method = soxr-vhq
 ```
 
 Restart pulseaudio:


### PR DESCRIPTION
Default values for pulseaudio are rather bad, like from 90s.
Those seem to be better. i want to include them because most people don't know that pulseaudio cannot detect their hardware specs.

I'm only not sure about this
high-priority = yes
nice-level = -15
after changes latency may be more noticeable, but not everybody may need it. This would help, but i don't know what to think about this solution. I use it only because of osu.

And i'm not an expert so i may be wrong with some settings. All the changes are base on aur wiki sometimes with support from some blogs to understand things better.

once more please correct my grammar.